### PR TITLE
Latest docker container require electric-sql update

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typescript": "^5.2.2",
     "vite": "^5.0.0",
     "wa-sqlite": "rhashimoto/wa-sqlite#master",
-    "electric-sql": "^0.7.1"
+    "electric-sql": "^0.11.1"
 
 
   }


### PR DESCRIPTION
Error message from docker container:
```
electric-1  | 15:34:57.933 pid=<0.4046.0> [info] GET /ws
electric-1  | 15:34:57.934 pid=<0.4046.0> [warning] Client WebSocket connection failed with reason: Cannot connect satellite version 0.7.0: this server requires >= 0.10.0 and <= 0.11.1
electric-1  | 15:34:57.934 pid=<0.4046.0> [info] Sent 400 in 124µs
```